### PR TITLE
modifying H so it uses a call set instead of a f set

### DIFF
--- a/src/structs/fractal_executable/hutchinson.jl
+++ b/src/structs/fractal_executable/hutchinson.jl
@@ -2,31 +2,39 @@ export Hutchinson
 
 mutable struct Hutchinson <: FractalExecutable
     fxs::Tuple
+    call_set::Tuple
     kwargs::Tuple
     fis::Tuple
     color_fxs::Tuple
+    color_call_set::Tuple
     color_kwargs::Tuple
     color_fis::Tuple
     prob_set::Tuple
     fnums::Tuple
 end
 
-Hutchinson() = Hutchinson((),(),(),(),(),(),(),())
+Hutchinson() = Hutchinson((),(),(),(),(),(),(),(),(),())
 
 Base.length(H::Hutchinson) = length(H.fnums)
 
 function Hutchinson(fo::FractalOperator)
-    kwargs, fis, fxs, color_kwargs, color_fis, color_fxs,
+    kwargs, fis, fxs, color_kwargs,
+         color_fis, color_fxs,
          prob_set, fnums = extract_info(fo)
-    return Hutchinson(fxs, kwargs, fis,
-                      color_fxs, color_kwargs, color_fis,
+    fxs, call_set = make_unique(fxs)
+    color_fxs, color_call_set = make_unique(color_fxs)
+    return Hutchinson(fxs, call_set, kwargs, fis,
+                      color_fxs, color_call_set, color_kwargs, color_fis,
                       prob_set, (fnums,))
 end
 
 function Hutchinson(fos::T) where T <: Union{Tuple, Vector{FractalOperator}}
-    kwargs, fis, fxs, color_kwargs, color_fis, color_fxs,
+    kwargs, fis, fxs,
+         color_kwargs, color_fis, color_fxs,
          prob_set, fnums = extract_info(fos)
-    return Hutchinson(fxs, kwargs, fis,
-                      color_fxs, color_kwargs, color_fis,
+    fxs, call_set = make_unique(fxs)
+    color_fxs, color_call_set = make_unique(color_fxs)
+    return Hutchinson(fxs, call_set, kwargs, fis,
+                      color_fxs, color_call_set, color_kwargs, color_fis,
                       prob_set, fnums)
 end

--- a/src/structs/fractal_operators.jl
+++ b/src/structs/fractal_operators.jl
@@ -178,6 +178,8 @@ function flatten(kwargs::Tuple, fis::Tuple, fxs::Tuple,
         new_probs = (new_probs..., temp_probs...)
         new_fnums = (new_fnums..., temp_fnums...)
     end
+    #new_fxs, new_call_set = make_unique(new_fxs)
+    #new_color_fxs, new_color_call_set = make_unique(new_color_fxs)
     return (new_kwargs, new_fis, new_fxs,
             new_color_kwargs, new_color_fis, new_color_fxs,
             new_probs, fnums)
@@ -207,4 +209,28 @@ end
 
 function extract_ops_info(op::FractalUserMethod)
     return (op.kwargs, op.fis, op.fx)
+end
+
+function make_unique(t::Tuple)
+    new_t, call_set = make_unique(t[1])
+    count = length(new_t)
+    for i = 2:length(t)
+        temp_t, temp_set = make_unique(t[i])
+        for j = 1:length(temp_t)
+            if in(temp_t[j], new_t)
+                idx = findfirst(isequal(temp_t[j]),new_t)
+                call_set = (call_set..., idx)
+            else
+                count += 1
+                new_t = (new_t...,temp_t[j])
+                call_set = (call_set..., count)
+            end
+        end
+    end
+
+    return new_t, call_set
+end
+
+function make_unique(a)
+    return (a,), (1,)
 end


### PR DESCRIPTION
An attempt to minimize the number of function for Fable by compressing them into a `call_set` variable. Note that this actually does not help with the LLVM-level branching issue.

Related to #66 